### PR TITLE
fix requirements.txt and setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ovos-local-backend
 ovos-stt-plugin-chromium
 ovos_workshop>=0.0.5a1
-ovos-stt-plugin-vosk-streaming
+ovos-stt-plugin-vosk
 ovos-tts-plugin-mimic
 ovos-tts-plugin-mimic2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
                       "ovos-local-backend",
                       "ovos-stt-plugin-chromium",
                       "ovos_workshop>=0.0.5a1",
-                      "ovos-stt-plugin-vosk-streaming",
+                      "ovos-stt-plugin-vosk",
                       "ovos-tts-plugin-mimic",
                       "ovos-tts-plugin-mimic2"],
     keywords='ovos skill plugin',


### PR DESCRIPTION
There doesn't seem to be a pip package for `ovos-stt-plugin-vosk-streaming`.  Changed to `ovos-stt-plugin-vosk`  