### PR TITLE
draft: support for backend list

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -242,10 +242,10 @@ class PairingSkill(OVOSSkill):
 
     @property
     def pairing_mode(self):
-        # if not is_gui_running() or not can_use_touch_mouse():
-        #     return PairingMode.VOICE
-        # else:
-        return PairingMode.GUI
+        if not is_gui_running() or not can_use_touch_mouse():
+            return PairingMode.VOICE
+        else:
+            return PairingMode.GUI
 
     # startup
     def initialize(self):

--- a/__init__.py
+++ b/__init__.py
@@ -242,10 +242,10 @@ class PairingSkill(OVOSSkill):
 
     @property
     def pairing_mode(self):
-        if not is_gui_running() or not can_use_touch_mouse():
-            return PairingMode.VOICE
-        else:
-            return PairingMode.GUI
+        # if not is_gui_running() or not can_use_touch_mouse():
+        #     return PairingMode.VOICE
+        # else:
+        return PairingMode.GUI
 
     # startup
     def initialize(self):
@@ -325,6 +325,18 @@ class PairingSkill(OVOSSkill):
                 {"name": "Portuguese", "code": "pt", "system_code": "pt_PT"},
                 {"name": "German", "code": "de", "system_code": "de_DE"},
                 {"name": "Dutch", "code": "nl", "system_code": "nl_NL"}
+            ]
+
+        if "backend_list" not in self.settings:
+            # backend_name: display name to display in UI
+            # backend_icon: display icon to display in UI
+            # backend_type: backend type for configuration
+            self.settings["backend_list"] = [
+                {"backend_name": "No Backend", "backend_icon": "icons/nobackend.svg", "backend_type": "offline"},
+                {"backend_name": "Personal Backend", "backend_icon": "icons/personal.svg", "backend_type": "personal"},
+                {"backend_name": "OpenVoice Backend", "backend_icon": "icons/ovos.svg", "backend_type": "ovos"},
+                {"backend_name": "Neon Backend", "backend_icon": "icons/neongecko.svg", "backend_type": "neon"},
+                {"backend_name": "Selene Backend", "backend_icon": "icons/selene.svg", "backend_type": "selene"}
             ]
 
         # read default plugins for simplified voice route from settings
@@ -583,6 +595,7 @@ class PairingSkill(OVOSSkill):
 
         self.state = SetupState.SELECTING_BACKEND
         self.send_stop_signal("pairing.confirmation.stop")
+        self.gui["backend_list"] = self.settings["backend_list"]
         self.handle_display_manager("BackendSelect")
         self.speak_dialog("backend.intro", wait=True)
         if self.pairing_mode != PairingMode.VOICE:
@@ -635,14 +648,15 @@ class PairingSkill(OVOSSkill):
                              BackendType.OFFLINE,
                              BackendType.PERSONAL):
             raise ValueError(f"Invalid selection: {selection}")
-        self.speak_dialog(f"backend.confirm.intro.{selection}", wait=True)
 
         if self.pairing_mode != PairingMode.VOICE:
             self.handle_display_manager(f"Backend{selection.title()}")
+            self.speak_dialog(f"backend.confirm.intro.{selection}", wait=True)
             self.speak_dialog("backend.confirm.gui",
                               {'backend': self._translate("backend", selection)},
                               wait=True)
         if self.pairing_mode != PairingMode.GUI:
+            self.speak_dialog(f"backend.confirm.intro.{selection}", wait=True)
             self._backend_confirmation_voice(selection)
 
     def _backend_confirmation_voice(self, selection):

--- a/locale/en-us/dialog/backend.confirm.intro.neon.dialog
+++ b/locale/en-us/dialog/backend.confirm.intro.neon.dialog
@@ -1,0 +1,1 @@
+Auto connects you with Neon Gecko backend API service to provide you with free API endpoints.

--- a/locale/en-us/dialog/backend.confirm.intro.ovos.dialog
+++ b/locale/en-us/dialog/backend.confirm.intro.ovos.dialog
@@ -1,0 +1,1 @@
+Auto connects you with Open Voice OS backend API service to provide you with free API endpoints.

--- a/ui/BackendButton.qml
+++ b/ui/BackendButton.qml
@@ -25,10 +25,11 @@ import Mycroft 1.0 as Mycroft
 
 Button {
     id: backendButtonControl
-    property string backendName
-    property string backendIcon
-    property string backendType
     property bool horizontalMode: false
+    topInset: Mycroft.Units.gridUnit / 2
+    leftInset: Mycroft.Units.gridUnit / 2
+    rightInset: Mycroft.Units.gridUnit / 2
+    bottomInset: Mycroft.Units.gridUnit / 2
 
     background: Rectangle {
         color: backendButtonControl.down ? "transparent" :  Kirigami.Theme.highlightColor
@@ -45,106 +46,37 @@ Button {
         }
     }
 
-    contentItem: Loader {
-        id: backendButtonLoader
-        sourceComponent: backendButtonControl.horizontalMode ? horizontalButtonContent : verticalButtonContent
-        onLoaded: {
-            backendButtonLoader.item.backendName = backendButtonControl.backendName
-            backendButtonLoader.item.backendIcon = backendButtonControl.backendIcon
+    contentItem: Item {
+
+        RowLayout {
+            id: backendButtonContentsLayout
+            anchors.fill: parent
+            anchors.margins: Mycroft.Units.gridUnit * 2
+            spacing: Mycroft.Units.gridUnit
+
+            Kirigami.Icon {
+                Layout.preferredWidth: backendButtonControl.horizontalMode ? parent.width * 0.3 : parent.height
+                Layout.preferredHeight: backendButtonControl.horizontalMode ? width : parent.height
+                Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                Layout.leftMargin: Mycroft.Units.gridUnit / 2
+                source: Qt.resolvedUrl(model.backend_icon)
+            }
+
+            Label {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                verticalAlignment: Text.AlignVCenter
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: backendButtonControl.horizontalMode ? parent.width * 0.125 : parent.height * 0.7
+                wrapMode: Text.WordWrap
+                text: model.backend_name
+            }
         }
     }
 
     onClicked: {
         Mycroft.SoundEffects.playClickedSound(Qt.resolvedUrl("sounds/clicked.wav"))
         triggerGuiEvent("mycroft.device.set.backend",
-        {"backend": backendButtonControl.backendType})
-    }
-
-    Component {
-        id: horizontalButtonContent
-
-        ColumnLayout {
-            id: backendButtonContentsLayout
-            spacing: Mycroft.Units.gridUnit
-            anchors.fill: parent
-            property string backendName
-            property string backendIcon
-
-            Item {
-                Layout.fillWidth: true
-                Layout.preferredHeight: parent.height < 300 ? 0 : Mycroft.Units.gridUnit * 2
-            }
-
-            Item {
-                Layout.preferredWidth: parent.width - Kirigami.Units.iconSizes.large * 4
-                Layout.preferredHeight: parent.width - Kirigami.Units.iconSizes.large * 4
-                Layout.minimumWidth: parent.height < 300 ? Kirigami.Units.iconSizes.large * 1.4 : Kirigami.Units.iconSizes.large * 2
-                Layout.minimumHeight: parent.height < 300 ? Kirigami.Units.iconSizes.large * 1.4 : Kirigami.Units.iconSizes.large * 2
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
-
-                Kirigami.Icon {
-                    width: parent.width * 0.8
-                    height: parent.height * 0.8
-                    anchors.centerIn: parent
-                    source: backendButtonContentsLayout.backendIcon
-                }
-            }
-
-            Label {
-                Layout.fillWidth: true                
-                Layout.fillHeight: true
-                Layout.leftMargin: Mycroft.Units.gridUnit 
-                Layout.rightMargin: Mycroft.Units.gridUnit
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
-
-                verticalAlignment: Text.AlignTop
-                horizontalAlignment: Text.AlignHCenter
-                wrapMode: Text.WordWrap
-                elide: Text.ElideRight
-                font.pixelSize: 32
-                minimumPixelSize: 8
-                fontSizeMode: Text.Fit
-                text: backendButtonContentsLayout.backendName
-            }
-
-            Item {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-            }
-        }
-    }
-
-    Component {
-        id: verticalButtonContent
-        
-        RowLayout {
-            id: backendButtonContentsLayout
-            spacing: Mycroft.Units.gridUnit
-            anchors.fill: parent
-            property string backendName
-            property string backendIcon
-
-            Kirigami.Icon {
-                Layout.preferredWidth: parent.height * 0.5
-                Layout.preferredHeight: width
-                Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
-                Layout.leftMargin: Mycroft.Units.gridUnit / 2
-                source: backendButtonContentsLayout.backendIcon
-            }
-
-            Label {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                Layout.leftMargin: Mycroft.Units.gridUnit / 2
-                Layout.rightMargin: Mycroft.Units.gridUnit / 2
-
-                verticalAlignment: Text.AlignVCenter
-                horizontalAlignment: Text.AlignHCenter
-                font.pixelSize: 32
-                minimumPixelSize: 16
-                fontSizeMode: Text.Fit
-                text: backendButtonContentsLayout.backendName
-            }
-        }
+        {"backend": model.backend_type})
     }
 }

--- a/ui/BackendNeon.qml
+++ b/ui/BackendNeon.qml
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2018 Aditya Mehra <aix.m@outlook.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import QtQuick.Layouts 1.4
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import org.kde.kirigami 2.5 as Kirigami
+import org.kde.plasma.core 2.0 as PlasmaCore
+import QtGraphicalEffects 1.0
+import Mycroft 1.0 as Mycroft
+
+Item {
+    id: backendView
+    anchors.fill: parent
+
+    property bool horizontalMode: backendView.width > backendView.height ? 1 :0
+
+    ListModel {
+        id: backendFeatureList
+        ListElement {
+            text: QT_TR_NOOP("Automatic Pairing")
+        }
+        ListElement {
+            text: QT_TR_NOOP("Multiple configurable STT Options")
+        }
+        ListElement {
+            text: QT_TR_NOOP("Multiple configurable TTS Options")
+        }
+        ListElement {
+            text: QT_TR_NOOP("Provides free API services for skills")
+        }
+    }
+
+    Rectangle {
+        color: Kirigami.Theme.backgroundColor
+        anchors.fill: parent
+
+        Rectangle {
+            id: topArea
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: Kirigami.Units.gridUnit * 4
+            color: Kirigami.Theme.highlightColor
+
+            Kirigami.Icon {
+                id: topAreaIcon
+                source: Qt.resolvedUrl("icons/neongecko.svg")
+                width: Kirigami.Units.iconSizes.large
+                height: width
+                anchors.left: parent.left
+                anchors.leftMargin: Mycroft.Units.gridUnit * 2
+                anchors.verticalCenter: parent.verticalCenter
+
+                ColorOverlay {
+                    anchors.fill: parent
+                    source: topAreaIcon
+                    color: Kirigami.Theme.textColor
+                }
+            }
+
+            Label {
+                id: selectLanguageHeader
+                anchors.left: topAreaIcon.right
+                anchors.top: parent.top
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.leftMargin: Mycroft.Units.gridUnit
+                text: qsTr("Neon Backend")
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+                font.pixelSize: topArea.height * 0.4
+                elide: Text.ElideLeft
+                maximumLineCount: 1
+                color: Kirigami.Theme.textColor
+            }
+
+            Kirigami.Separator {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: Kirigami.Units.largeSpacing
+                anchors.rightMargin: Kirigami.Units.largeSpacing
+                height: 1
+                color: Kirigami.Theme.textColor
+            }
+        }
+
+        ColumnLayout {
+            id: middleArea
+            anchors.bottom: bottomArea.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: topArea.bottom
+            anchors.margins: Mycroft.Units.gridUnit * 2
+
+            Label {
+                id: warnText
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignLeft
+                color: Kirigami.Theme.textColor
+                wrapMode: Text.WordWrap
+                font.pixelSize: horizontalMode ? (backendView.height > 600 ? topArea.height * 0.4 : topArea.height * 0.25) : topArea.height * 0.3
+                text: qsTr("Official backend service provided by NeonGecko")
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.largeSpacing
+            }
+
+            ListView {
+                id: qViewL
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                model: backendFeatureList
+                clip: true
+                currentIndex: -1
+                spacing: 5
+                property int cellWidth: qViewL.width
+                property int cellHeight: qViewL.height / 4.6
+                delegate: Rectangle {
+                    width: qViewL.cellWidth
+                    height: qViewL.cellHeight
+                    radius: 10
+                    color: Qt.darker(Kirigami.Theme.backgroundColor, 1.5)
+
+                    Rectangle {
+                        id: symb
+                        anchors.left: parent.left
+                        anchors.leftMargin: Kirigami.Units.smallSpacing
+                        anchors.verticalCenter: parent.verticalCenter
+                        height: parent.height - Kirigami.Units.largeSpacing
+                        width: Kirigami.Units.iconSizes.medium
+                        color: Kirigami.Theme.highlightColor
+                        radius: width
+                    }
+
+                    Label {
+                        id: cItm
+                        anchors.left: symb.right
+                        anchors.leftMargin: Kirigami.Units.largeSpacing
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.bottom: parent.bottom
+                        wrapMode: Text.WordWrap
+                        anchors.margins: Kirigami.Units.smallSpacing
+                        verticalAlignment: Text.AlignVCenter
+                        color: Kirigami.Theme.textColor
+                        text: qsTr(model.text)
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            id: bottomArea
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: Kirigami.Units.gridUnit * 3
+            color: Kirigami.Theme.highlightColor
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: Kirigami.Units.largeSpacing
+
+                Button {
+                    id: btnba1
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    background: Rectangle {
+                        color: btnba1.down ? "transparent" :  Kirigami.Theme.backgroundColor
+                        border.width: 3
+                        border.color: Kirigami.Theme.backgroundColor
+                        radius: 3
+                    }
+
+                    contentItem: Item {
+                        RowLayout {
+                            anchors.centerIn: parent
+
+                            Kirigami.Icon {
+                                Layout.fillHeight: true
+                                Layout.preferredWidth: height
+                                Layout.alignment: Qt.AlignVCenter
+                                source: "arrow-left"
+                            }
+
+                            Kirigami.Heading {
+                                level: 2
+                                Layout.fillHeight: true
+                                wrapMode: Text.WordWrap
+                                font.bold: true
+                                color: Kirigami.Theme.textColor
+                                text: qsTr("Backend Selection")
+                                verticalAlignment: Text.AlignVCenter
+                                horizontalAlignment: Text.AlignLeft
+                            }
+                        }
+                    }
+
+                    onClicked: {
+                        Mycroft.SoundEffects.playClickedSound(Qt.resolvedUrl("sounds/clicked.wav"))
+                        triggerGuiEvent("mycroft.return.select.backend", {"page": "offline"})
+                    }
+                }
+
+                Button {
+                    id: btnba2
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    background: Rectangle {
+                        color: btnba2.down ? "transparent" :  Kirigami.Theme.backgroundColor
+                        border.width: 3
+                        border.color: Kirigami.Theme.backgroundColor
+                        radius: 3
+                    }
+
+                    contentItem: Item {
+                        RowLayout {
+                            anchors.centerIn: parent
+
+                            Kirigami.Icon {
+                                Layout.fillHeight: true
+                                Layout.preferredWidth: height
+                                Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                                source: "dialog-ok-apply"
+                            }
+
+                            Kirigami.Heading {
+                                level: 2
+                                Layout.fillHeight: true
+                                Layout.alignment: Qt.AlignRight
+                                wrapMode: Text.WordWrap
+                                font.bold: true
+                                color: Kirigami.Theme.textColor
+                                text: qsTr("Confirm")
+                                verticalAlignment: Text.AlignVCenter
+                                horizontalAlignment: Text.AlignRight
+                            }
+                        }
+                    }
+
+                    onClicked: {
+                        Mycroft.SoundEffects.playClickedSound(Qt.resolvedUrl("sounds/clicked.wav"))
+                        triggerGuiEvent("mycroft.device.confirm.backend", {"backend": "neon"})
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/ui/BackendOvos.qml
+++ b/ui/BackendOvos.qml
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2018 Aditya Mehra <aix.m@outlook.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import QtQuick.Layouts 1.4
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import org.kde.kirigami 2.5 as Kirigami
+import org.kde.plasma.core 2.0 as PlasmaCore
+import QtGraphicalEffects 1.0
+import Mycroft 1.0 as Mycroft
+
+Item {
+    id: backendView
+    anchors.fill: parent
+
+    property bool horizontalMode: backendView.width > backendView.height ? 1 :0
+
+    ListModel {
+        id: backendFeatureList
+        ListElement {
+            text: QT_TR_NOOP("Automatic Pairing")
+        }
+        ListElement {
+            text: QT_TR_NOOP("Multiple configurable STT Options")
+        }
+        ListElement {
+            text: QT_TR_NOOP("Multiple configurable TTS Options")
+        }
+        ListElement {
+            text: QT_TR_NOOP("Provides free API services for skills")
+        }
+    }
+
+    Rectangle {
+        color: Kirigami.Theme.backgroundColor
+        anchors.fill: parent
+
+        Rectangle {
+            id: topArea
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: Kirigami.Units.gridUnit * 4
+            color: Kirigami.Theme.highlightColor
+
+            Kirigami.Icon {
+                id: topAreaIcon
+                source: Qt.resolvedUrl("icons/ovos.svg")
+                width: Kirigami.Units.iconSizes.large
+                height: width
+                anchors.left: parent.left
+                anchors.leftMargin: Mycroft.Units.gridUnit * 2
+                anchors.verticalCenter: parent.verticalCenter
+
+                ColorOverlay {
+                    anchors.fill: parent
+                    source: topAreaIcon
+                    color: Kirigami.Theme.textColor
+                }
+            }
+
+            Label {
+                id: selectLanguageHeader
+                anchors.left: topAreaIcon.right
+                anchors.top: parent.top
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.leftMargin: Mycroft.Units.gridUnit
+                text: qsTr("OpenVoice Backend")
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+                font.pixelSize: topArea.height * 0.4
+                elide: Text.ElideLeft
+                maximumLineCount: 1
+                color: Kirigami.Theme.textColor
+            }
+
+            Kirigami.Separator {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: Kirigami.Units.largeSpacing
+                anchors.rightMargin: Kirigami.Units.largeSpacing
+                height: 1
+                color: Kirigami.Theme.textColor
+            }
+        }
+
+        ColumnLayout {
+            id: middleArea
+            anchors.bottom: bottomArea.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: topArea.bottom
+            anchors.margins: Mycroft.Units.gridUnit * 2
+
+            Label {
+                id: warnText
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignLeft
+                color: Kirigami.Theme.textColor
+                wrapMode: Text.WordWrap
+                font.pixelSize: horizontalMode ? (backendView.height > 600 ? topArea.height * 0.4 : topArea.height * 0.25) : topArea.height * 0.3
+                text: qsTr("Official backend service provided by OpenVoice OS")
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.largeSpacing
+            }
+
+            ListView {
+                id: qViewL
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                model: backendFeatureList
+                clip: true
+                currentIndex: -1
+                spacing: 5
+                property int cellWidth: qViewL.width
+                property int cellHeight: qViewL.height / 4.6
+                delegate: Rectangle {
+                    width: qViewL.cellWidth
+                    height: qViewL.cellHeight
+                    radius: 10
+                    color: Qt.darker(Kirigami.Theme.backgroundColor, 1.5)
+
+                    Rectangle {
+                        id: symb
+                        anchors.left: parent.left
+                        anchors.leftMargin: Kirigami.Units.smallSpacing
+                        anchors.verticalCenter: parent.verticalCenter
+                        height: parent.height - Kirigami.Units.largeSpacing
+                        width: Kirigami.Units.iconSizes.medium
+                        color: Kirigami.Theme.highlightColor
+                        radius: width
+                    }
+
+                    Label {
+                        id: cItm
+                        anchors.left: symb.right
+                        anchors.leftMargin: Kirigami.Units.largeSpacing
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.bottom: parent.bottom
+                        wrapMode: Text.WordWrap
+                        anchors.margins: Kirigami.Units.smallSpacing
+                        verticalAlignment: Text.AlignVCenter
+                        color: Kirigami.Theme.textColor
+                        text: qsTr(model.text)
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            id: bottomArea
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: Kirigami.Units.gridUnit * 3
+            color: Kirigami.Theme.highlightColor
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: Kirigami.Units.largeSpacing
+
+                Button {
+                    id: btnba1
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    background: Rectangle {
+                        color: btnba1.down ? "transparent" :  Kirigami.Theme.backgroundColor
+                        border.width: 3
+                        border.color: Kirigami.Theme.backgroundColor
+                        radius: 3
+                    }
+
+                    contentItem: Item {
+                        RowLayout {
+                            anchors.centerIn: parent
+
+                            Kirigami.Icon {
+                                Layout.fillHeight: true
+                                Layout.preferredWidth: height
+                                Layout.alignment: Qt.AlignVCenter
+                                source: "arrow-left"
+                            }
+
+                            Kirigami.Heading {
+                                level: 2
+                                Layout.fillHeight: true
+                                wrapMode: Text.WordWrap
+                                font.bold: true
+                                color: Kirigami.Theme.textColor
+                                text: qsTr("Backend Selection")
+                                verticalAlignment: Text.AlignVCenter
+                                horizontalAlignment: Text.AlignLeft
+                            }
+                        }
+                    }
+
+                    onClicked: {
+                        Mycroft.SoundEffects.playClickedSound(Qt.resolvedUrl("sounds/clicked.wav"))
+                        triggerGuiEvent("mycroft.return.select.backend", {"page": "offline"})
+                    }
+                }
+
+                Button {
+                    id: btnba2
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    background: Rectangle {
+                        color: btnba2.down ? "transparent" :  Kirigami.Theme.backgroundColor
+                        border.width: 3
+                        border.color: Kirigami.Theme.backgroundColor
+                        radius: 3
+                    }
+
+                    contentItem: Item {
+                        RowLayout {
+                            anchors.centerIn: parent
+
+                            Kirigami.Icon {
+                                Layout.fillHeight: true
+                                Layout.preferredWidth: height
+                                Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                                source: "dialog-ok-apply"
+                            }
+
+                            Kirigami.Heading {
+                                level: 2
+                                Layout.fillHeight: true
+                                Layout.alignment: Qt.AlignRight
+                                wrapMode: Text.WordWrap
+                                font.bold: true
+                                color: Kirigami.Theme.textColor
+                                text: qsTr("Confirm")
+                                verticalAlignment: Text.AlignVCenter
+                                horizontalAlignment: Text.AlignRight
+                            }
+                        }
+                    }
+
+                    onClicked: {
+                        Mycroft.SoundEffects.playClickedSound(Qt.resolvedUrl("sounds/clicked.wav"))
+                        triggerGuiEvent("mycroft.device.confirm.backend", {"backend": "ovos"})
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/ui/BackendSelect.qml
+++ b/ui/BackendSelect.qml
@@ -27,7 +27,7 @@ Item {
     id: backendView
     anchors.fill: parent
     property bool horizontalMode: backendView.width > backendView.height ? 1 : 0
-    property bool languageSelectionEnabled: true //sessionData.language_selection_enabled ? Boolean(sessionData.language_selection_enabled) : 0
+    property bool languageSelectionEnabled: sessionData.language_selection_enabled ? Boolean(sessionData.language_selection_enabled) : 0
 
     Rectangle {
         color: Kirigami.Theme.backgroundColor

--- a/ui/BackendSelect.qml
+++ b/ui/BackendSelect.qml
@@ -27,6 +27,7 @@ Item {
     id: backendView
     anchors.fill: parent
     property bool horizontalMode: backendView.width > backendView.height ? 1 : 0
+    property bool languageSelectionEnabled: true //sessionData.language_selection_enabled ? Boolean(sessionData.language_selection_enabled) : 0
 
     Rectangle {
         color: Kirigami.Theme.backgroundColor
@@ -37,7 +38,7 @@ Item {
             anchors.top: parent.top
             anchors.left: parent.left
             anchors.right: parent.right
-            height: Kirigami.Units.gridUnit * 4
+            height: backendSelectionGridView.count < 4 ? Kirigami.Units.gridUnit * 4 : Kirigami.Units.gridUnit * 3
             color: Kirigami.Theme.highlightColor
 
             Kirigami.Icon {
@@ -83,68 +84,41 @@ Item {
             }
         }
 
+        ScrollBar {
+            id: backendScroller
+            anchors.right: parent.right
+            anchors.top: topArea.bottom
+            anchors.bottom: bottomArea.top
+            width: Mycroft.Units.gridUnit
+        }
+
         ColumnLayout {
             id: middleArea
             anchors.bottom: bottomArea.top
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.top: topArea.bottom
-            anchors.margins: Mycroft.Units.gridUnit * 2
-        
-            Label {
-                id: warnText
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignTop
-                wrapMode: Text.WordWrap
-                font.pixelSize: horizontalMode ? (backendView.height > 600 ? topArea.height * 0.4 : topArea.height * 0.25) : topArea.height * 0.3
-                color: Kirigami.Theme.textColor
-                text: qsTr("A backend provides services used by OpenVoiceOS Core")
-            }
+            anchors.leftMargin: Mycroft.Units.gridUnit * 2
+            anchors.rightMargin: Mycroft.Units.gridUnit * 2
+            anchors.topMargin: backendSelectionGridView.count < 4 ? Mycroft.Units.gridUnit * 2 : Mycroft.Units.gridUnit / 2
+            anchors.bottomMargin: backendSelectionGridView.count < 4 ? Mycroft.Units.gridUnit * 2 : Mycroft.Units.gridUnit / 2
 
             Item {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                Layout.margins: horizontalMode ? Kirigami.Units.largeSpacing : 0
-        
-                GridLayout {
-                    id: backendsGrid
+
+                GridView {
+                    id: backendSelectionGridView
+                    clip: true
                     anchors.fill: parent
-                    z: 1
-                    columns: horizontalMode ? 3 : 1
-                    columnSpacing: Kirigami.Units.largeSpacing
-                    Layout.alignment: Qt.AlignVCenter
-
-                    BackendButton {
-                        id: bt1
-                        backendName: "Selene " + qsTr("Backend")
-                        backendIcon: Qt.resolvedUrl("icons/selene.svg")
-                        backendType: "selene"
+                    cellWidth: horizontalMode ? width / 3 : width
+                    cellHeight: horizontalMode ? (backendSelectionGridView.count < 4 ? height : height / 2) : Kirigami.Units.gridUnit * 4
+                    model: sessionData.backend_list
+                    ScrollBar.vertical: backendScroller
+                    delegate: BackendButton {
+                        implicitWidth: backendSelectionGridView.cellWidth
+                        implicitHeight: backendSelectionGridView.cellHeight
                         horizontalMode: backendView.horizontalMode
-
-                        Layout.preferredWidth: horizontalMode ? (parent.width / 3 - Kirigami.Units.gridUnit) : parent.width
-                        Layout.fillHeight: true
-                    }
-
-                    BackendButton {
-                        id: bt2
-                        backendName: qsTr("Personal Backend")
-                        backendIcon: Qt.resolvedUrl("icons/personal.svg")
-                        backendType: "personal"
-                        horizontalMode: backendView.horizontalMode
-                        
-                        Layout.preferredWidth: horizontalMode ? (parent.width / 3 - Kirigami.Units.gridUnit) : parent.width
-                        Layout.fillHeight: true
-                    }
-
-                    BackendButton {
-                        id: bt3
-                        backendName: qsTr("No Backend")
-                        backendIcon: Qt.resolvedUrl("icons/nobackend.svg")
-                        backendType: "offline"
-                        horizontalMode: backendView.horizontalMode
-
-                        Layout.preferredWidth: horizontalMode ? (parent.width / 3 - Kirigami.Units.gridUnit) : parent.width
-                        Layout.fillHeight: true
                     }
                 }
             }
@@ -156,19 +130,54 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: parent.bottom
-            height: Kirigami.Units.gridUnit * 3
+            height: backendView.horizontalMode ? (backendView.languageSelectionEnabled ? Kirigami.Units.gridUnit * 3 : Kirigami.Units.gridUnit * 2) : (backendView.languageSelectionEnabled ? Kirigami.Units.gridUnit * 5 : Kirigami.Units.gridUnit * 3)
             color: Kirigami.Theme.highlightColor
 
-            RowLayout {
+            GridLayout {
                 anchors.fill: parent
                 anchors.margins: Kirigami.Units.largeSpacing
+                columns: backendView.horizontalMode && backendView.languageSelectionEnabled ? 2 : 1
+
+                Item {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: backendView.horizontalMode ? parent.height : parent.height / 2
+
+                    Kirigami.Icon {
+                        id: warnTextIcon
+                        source: "documentinfo"
+                        width: Kirigami.Units.iconSizes.mediumSmall
+                        height: width
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        ColorOverlay {
+                            anchors.fill: parent
+                            source: warnTextIcon
+                            color: Kirigami.Theme.textColor
+                        }
+                    }
+
+                    Label {
+                        id: warnText
+                        anchors.left: warnTextIcon.right
+                        anchors.leftMargin: Mycroft.Units.gridUnit / 2
+                        anchors.top: parent.top
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        horizontalAlignment: Text.AlignLeft
+                        verticalAlignment: Text.AlignVCenter
+                        wrapMode: Text.WordWrap
+                        color: Kirigami.Theme.textColor
+                        text: qsTr("A backend provides services used by OpenVoiceOS Core")
+                    }
+                }
 
                 Button {
                     id: btnba1
-                    Layout.preferredWidth: backendView.horizontalMode ? parent.width / 2 : parent.width
+                    Layout.preferredWidth: backendView.horizontalMode ? Kirigami.Units.gridUnit * 10 : parent.width
                     Layout.fillHeight: true
-                    enabled: sessionData.language_selection_enabled ? Boolean(sessionData.language_selection_enabled) : 0
-                    visible: sessionData.language_selection_enabled ? Boolean(sessionData.language_selection_enabled) : 0
+                    enabled: backendView.languageSelectionEnabled ? 1 : 0
+                    visible: backendView.languageSelectionEnabled ? 1 : 0
 
                     background: Rectangle {
                         color: btnba1.down ? "transparent" :  Kirigami.Theme.backgroundColor
@@ -178,10 +187,13 @@ Item {
                     }
 
                     contentItem: Item {
+                        id: contentsForBtnBa1
                         RowLayout {
                             anchors.centerIn: parent
 
                             Kirigami.Icon {
+                                Layout.topMargin: 5
+                                Layout.bottomMargin: 5
                                 Layout.fillHeight: true
                                 Layout.preferredWidth: height
                                 Layout.alignment: Qt.AlignVCenter

--- a/ui/icons/neongecko.svg
+++ b/ui/icons/neongecko.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="256"
+   height="256"
+   viewBox="0 0 67.733331 67.733331"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="neongecko.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2">
+    <rect
+       x="62.534964"
+       y="83.593183"
+       width="168.56232"
+       height="123.14891"
+       id="rect1011" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="25.357143"
+     inkscape:cy="47.142857"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="989"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-229.26668)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#f2f2f2;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:16,2;stroke-dashoffset:19.6;stroke-opacity:1"
+       id="path985"
+       sodipodi:sides="4"
+       sodipodi:cx="33.866669"
+       sodipodi:cy="263.13336"
+       sodipodi:r1="25.794624"
+       sodipodi:r2="23.831125"
+       sodipodi:arg1="0.78539816"
+       sodipodi:arg2="1.5707963"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 52.106223,281.37292 -36.479108,0 0,-36.47911 36.479107,0 z" />
+    <g
+       aria-label="N"
+       transform="matrix(0.73730279,0,0,0.73730279,-30.206386,201.59719)"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f2f2f2;fill-opacity:1;stroke:none"
+       id="flowRoot1007-3" />
+    <g
+       aria-label="NG"
+       transform="matrix(0.20334574,0,0,0.20334574,7.1710258,236.42066)"
+       id="text1009"
+       style="font-size:85.3333px;white-space:pre;shape-inside:url(#rect1011);display:inline;fill:#ececec">
+      <path
+         d="m 128.53513,156.6114 q 0,1.16667 -0.45833,2.16667 -0.41667,1 -1.16667,1.75 -0.70833,0.70833 -1.70833,1.125 -1,0.41666 -2.125,0.41666 -1,0 -2.04167,-0.375 -1,-0.375 -1.79166,-1.20833 L 79.660149,119.15308 V 161.2364 H 68.82682 v -55.12498 q 0,-1.66666 0.916667,-3 0.958333,-1.375 2.416665,-2.04166 1.541666,-0.625 3.166666,-0.29167 1.624999,0.29167 2.791665,1.5 l 39.583317,41.29165 v -42.08332 h 10.83333 z"
+         style="font-family:Audiowide;-inkscape-font-specification:Audiowide"
+         id="path1171" />
+      <path
+         d="m 200.07676,155.77807 q 0,1.16667 -0.41666,2.16666 -0.41667,1 -1.16667,1.75 -0.70833,0.70834 -1.70833,1.125 -1,0.41667 -2.16667,0.41667 h -39.08332 q -1.49999,0 -3.24999,-0.33333 -1.70834,-0.375 -3.41667,-1.125 -1.66667,-0.75 -3.20833,-1.91667 -1.54167,-1.20833 -2.75,-2.875 -1.16667,-1.70833 -1.875,-3.91666 -0.70833,-2.25 -0.70833,-5.04167 v -29.33332 q 0,-1.5 0.33333,-3.20833 0.375,-1.75 1.125,-3.41667 0.75,-1.70833 1.95833,-3.24999 1.20834,-1.54167 2.875,-2.70834 1.70833,-1.20833 3.91667,-1.91666 2.20833,-0.70834 4.99999,-0.70834 h 44.04165 v 10.83333 h -44.04165 q -2.12499,0 -3.24999,1.125 -1.125,1.125 -1.125,3.33334 v 29.24998 q 0,2.08334 1.125,3.25 1.16666,1.125 3.24999,1.125 h 33.70832 v -13.58333 h -28.83332 v -10.91666 h 34.20832 q 1.16667,0 2.16667,0.45833 1,0.41667 1.70833,1.16667 0.75,0.75 1.16667,1.75 0.41666,0.95833 0.41666,2.08333 z"
+         style="font-family:Audiowide;-inkscape-font-specification:Audiowide"
+         id="path1173" />
+    </g>
+  </g>
+</svg>

--- a/ui/icons/ovos.svg
+++ b/ui/icons/ovos.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="256"
+   height="256"
+   viewBox="0 0 67.733331 67.733331"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="ovos.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2">
+    <rect
+       x="62.534964"
+       y="83.593183"
+       width="168.56232"
+       height="123.14891"
+       id="rect1011" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.7165522"
+     inkscape:cx="-7.282039"
+     inkscape:cy="161.95255"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="989"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-229.26668)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#f2f2f2;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:16,2;stroke-dashoffset:2.4;stroke-opacity:1"
+       id="path985"
+       sodipodi:sides="4"
+       sodipodi:cx="33.866669"
+       sodipodi:cy="263.13336"
+       sodipodi:r1="25.794624"
+       sodipodi:r2="23.831125"
+       sodipodi:arg1="0.78539816"
+       sodipodi:arg2="1.5707963"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 52.106223,281.37292 -36.479108,0 0,-36.47911 36.479107,0 z"
+       transform="translate(0,-1.514974e-5)" />
+    <g
+       aria-label="N"
+       transform="matrix(0.73730279,0,0,0.73730279,-30.206386,201.59719)"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f2f2f2;fill-opacity:1;stroke:none"
+       id="flowRoot1007-3" />
+    <g
+       aria-label="OV"
+       transform="matrix(0.20334574,0,0,0.20334574,6.6450875,236.42156)"
+       id="text1009"
+       style="font-size:85.3333px;white-space:pre;shape-inside:url(#rect1011);display:inline;fill:#ececec">
+      <g
+         id="g343"
+         transform="matrix(1.0522769,0,0,1.0522769,-6.9982281,-6.8671499)">
+        <path
+           d="m 131.53513,137.06974 q 0,5.45833 -1.875,10.04167 -1.875,4.58333 -5.20833,7.91666 -3.33333,3.33333 -7.91667,5.20833 -4.54166,1.83333 -9.91666,1.83333 H 91.951811 q -5.374998,0 -9.95833,-1.83333 -4.583331,-1.875 -7.916663,-5.20833 -3.333332,-3.33333 -5.249998,-7.91666 -1.874999,-4.58334 -1.874999,-10.04167 v -11.41666 q 0,-5.41666 1.874999,-9.99999 1.916666,-4.625 5.249998,-7.91667 3.333332,-3.33333 7.916663,-5.20833 4.583332,-1.875 9.95833,-1.875 h 14.666659 q 5.375,0 9.91666,1.875 4.58334,1.875 7.91667,5.20833 3.33333,3.29167 5.20833,7.91667 1.875,4.58333 1.875,9.99999 z M 120.7018,125.65308 q 0,-3.20833 -1.04167,-5.79166 -1,-2.625 -2.875,-4.45833 -1.83333,-1.875 -4.45833,-2.875 -2.58333,-1.04167 -5.70833,-1.04167 H 91.951811 q -3.166666,0 -5.791665,1.04167 -2.583332,1 -4.458331,2.875 -1.874999,1.83333 -2.916666,4.45833 -0.999999,2.58333 -0.999999,5.79166 v 11.41666 q 0,3.20834 0.999999,5.83333 1.041667,2.58334 2.916666,4.45834 1.874999,1.83333 4.458331,2.87499 2.624999,1 5.791665,1 h 14.583329 q 3.16666,0 5.75,-1 2.62499,-1.04166 4.49999,-2.87499 1.875,-1.875 2.875,-4.45834 1.04167,-2.62499 1.04167,-5.83333 z"
+           style="font-family:Audiowide;-inkscape-font-specification:Audiowide"
+           id="path1187" />
+        <path
+           d="m 200.7851,101.48642 -28.29166,57.62498 q -0.66667,1.33333 -2,2.125 -1.29166,0.83333 -2.875,0.83333 -1.54166,0 -2.875,-0.83333 -1.29166,-0.79167 -2,-2.125 l -28.24998,-57.62498 h 12.12499 l 20.99999,43.04165 21.08333,-43.04165 z"
+           style="font-family:Audiowide;-inkscape-font-specification:Audiowide"
+           id="path1189" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
- Builds backend_list from a list of backend dicts
- GUI: Adds support to show 6 backends
- GUI: Adds icon for ovos and neon backends
- *WIP*

![image](https://user-images.githubusercontent.com/33701864/205902796-50fb3787-7b1b-460c-8a20-c0c97f013a66.png)
![image](https://user-images.githubusercontent.com/33701864/205902830-807bd30d-5a66-4144-af1e-11e520577414.png)
